### PR TITLE
Add MacOS & Edge support

### DIFF
--- a/PdfPageImageSaver.java
+++ b/PdfPageImageSaver.java
@@ -4,6 +4,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -22,9 +24,11 @@ import java.util.Set;
 public class PdfPageImageSaver {
 
     public static void main(String[] args) throws java.io.IOException {
-        // Determine the OS and set the appropriate path for ChromeDriver
+        // Determine the OS and set the appropriate path for the driver
         String os = System.getProperty("os.name").toLowerCase();
-        String driverPath = "resources/drivers/chromedriver"; // Default path
+
+        String browser = (args.length > 0) ? args[0].toLowerCase() : "chrome";
+        String driverPath = "resources/drivers/" + (browser.equals("edge") ? "msedgedriver" : "chromedriver");
 
         if (os.contains("win")) {
             driverPath += ".exe"; // Windows executable
@@ -37,16 +41,17 @@ public class PdfPageImageSaver {
             return; // Exit if the OS is unsupported
         }
 
-        // Set the path for the ChromeDriver executable
-        System.setProperty("webdriver.chrome.driver", driverPath);
-
-        // Optional: Run Chrome in headless mode
-        ChromeOptions options = new ChromeOptions();
-        // Comment out the headless option if you want to see the browser UI
-        // options.addArguments("--headless");
-
-        // Initialize WebDriver
-        WebDriver driver = new ChromeDriver(options);
+        WebDriver driver;
+        if (browser.equals("edge")) {
+            System.setProperty("webdriver.edge.driver", driverPath);
+            EdgeOptions options = new EdgeOptions();
+            driver = new EdgeDriver(options);
+        } else {
+            System.setProperty("webdriver.chrome.driver", driverPath);
+            ChromeOptions options = new ChromeOptions();
+            // options.addArguments("--headless");
+            driver = new ChromeDriver(options);
+        }
 
         // The target URL of the local index.html file
         String url = new File("index.html").getAbsolutePath();  // Gets the absolute path of the local index.html

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This software allows you to download PDF files that are hosted using PDFJS / PDF.js
 
+The downloader now supports Windows, Linux and MacOS systems.
+
 Public Release V1.0.0 09/01/2024
 
 HOW TO START THE PROGRAM: With java installed, open a command line in the KripplysPDFDownloader folder. 
@@ -13,8 +15,8 @@ HOW TO START THE PROGRAM: With java installed, open a command line in the Krippl
 AUTHORS: Kripply.com
 
 USER INSTRUCTIONS:
-The software will open an automated instance of Chrome Browser for you.
-In the automated Chrome Browser, navigate to the pdf you want to download.
+The software will open an automated instance of your chosen browser (Chrome or Edge).
+In the automated browser, navigate to the pdf you want to download.
 From there, return to the terminal and follow the on screen instructions.
 If your internet connection is slow, try adjusting the delay in settings/delay.txt.
 Adjusting the delay tells the downloader to wait longer for the page to render before attempting to download it.


### PR DESCRIPTION
## Summary
- support Mac x64/arm64 in ChromeDriver downloader
- allow choosing Edge browser and download appropriate driver
- add Edge driver detection utilities
- allow browser selection in PdfPageImageSaver
- update documentation for MacOS and Edge support

## Testing
- `javac -cp lib/seleniumjars/selenium-java-4.23.1.jar ChromeDriverDownloader.java PdfPageImageSaver.java` *(fails: package org.json does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_683ba1223b74832595cd65593311fb01