### PR TITLE
Fix NPE when EdgeDriver fetch fails

### DIFF
--- a/ChromeDriverDownloader.java
+++ b/ChromeDriverDownloader.java
@@ -127,11 +127,22 @@ public class ChromeDriverDownloader {
                 System.out.println("Updating EdgeDriver...");
 
                 String latestDriverVersion = fetchLatestEdgeDriverVersion();
+                if (latestDriverVersion == null || latestDriverVersion.isEmpty()) {
+                    System.out.println("Failed to fetch the latest EdgeDriver version. Skipping update.");
+                    PdfPageImageSaver.main(new String[]{"edge"});
+                    return;
+                }
+
                 int latestDriverMajorVersion = Integer.parseInt(latestDriverVersion.split("\\.")[0]);
 
                 String driverVersion;
                 if (installedMajorVersion > latestDriverMajorVersion) {
                     driverVersion = fetchCompatibleEdgeDriverVersion(installedMajorVersion);
+                    if (driverVersion == null) {
+                        System.out.println("Could not find a compatible EdgeDriver version.");
+                        PdfPageImageSaver.main(new String[]{"edge"});
+                        return;
+                    }
                 } else {
                     driverVersion = latestDriverVersion;
                 }


### PR DESCRIPTION
## Summary
- handle missing EdgeDriver version when the download site can't be reached

## Testing
- `javac -cp "lib/seleniumjars/*" ChromeDriverDownloader.java` *(fails: package org.json does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_683be21875848325b472a3c78154b993