### PR TITLE
Replace pdfbox usage with simple internal writer

### DIFF
--- a/PDFConverter.java
+++ b/PDFConverter.java
@@ -1,12 +1,8 @@
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+// Removed Apache PDFBox dependencies and replaced with a minimal
+// implementation to avoid missing library issues.
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -65,21 +61,10 @@ public class PDFConverter {
         }
         // Document path
         File docPath = new File(filePath + title);
-        // Create PDF document
+        // Create PDF document using the simple writer implementation
         System.out.println("Creating PDF...");
-        try (PDDocument document = new PDDocument()) {
-            for (String imagePath : imagePaths) {
-                addImageToPdf(document, imagePath);
-                currentIndex++;
-                System.out.println("Added page " + imagePath);
-                // Calculate and display progress percentage
-                 // Calculate progress percentage
-            int progressPercentage = (int) ((currentIndex / (double) imagePaths.size()) * 100);
-            System.out.println("Progress: " + progressPercentage + "% complete.");
-        }
-
-            // Save the PDF document
-            document.save(filePath + title);
+        try {
+            SimplePDFWriter.createPdf(imagePaths, filePath + title);
             System.out.println("Deleting temporary files...");
             Thread.sleep(200);
             for (File file : files) {
@@ -136,17 +121,6 @@ public class PDFConverter {
         }
     }
 
-    private static void addImageToPdf(PDDocument document, String imagePath) throws IOException {
-        // Load the image
-        PDImageXObject image = PDImageXObject.createFromFile(imagePath, document);
-
-        // Create a new page with the size of the image
-        PDPage page = new PDPage(new PDRectangle(image.getWidth(), image.getHeight()));
-        document.addPage(page);
-
-        // Draw the image on the page
-        try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
-            contentStream.drawImage(image, 0, 0, image.getWidth(), image.getHeight());
-        }
-    }
+    // The previous implementation relied on Apache PDFBox to add pages.
+    // With the simple writer, this helper is no longer required.
 }

--- a/SimplePDFWriter.java
+++ b/SimplePDFWriter.java
@@ -1,0 +1,118 @@
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+
+/**
+ * Minimal PDF writer that embeds each image as a page.
+ * It avoids external dependencies like Apache PDFBox.
+ */
+public class SimplePDFWriter {
+
+    private static class ImageInfo {
+        final byte[] data;
+        final int width;
+        final int height;
+        ImageInfo(byte[] d, int w, int h) { this.data = d; this.width = w; this.height = h; }
+    }
+
+    /**
+     * Creates a PDF file from a list of image paths.
+     */
+    public static void createPdf(List<String> imagePaths, String outputPath) throws IOException {
+        List<ImageInfo> images = new ArrayList<>();
+        for (String path : imagePaths) {
+            BufferedImage img = ImageIO.read(new File(path));
+            if (img == null) continue;
+            BufferedImage rgb = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_INT_RGB);
+            Graphics2D g = rgb.createGraphics();
+            g.drawImage(img, 0, 0, null);
+            g.dispose();
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageWriter writer = ImageIO.getImageWritersByFormatName("jpg").next();
+            ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
+            writer.setOutput(ios);
+            ImageWriteParam param = writer.getDefaultWriteParam();
+            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            param.setCompressionQuality(0.8f);
+            writer.write(null, new IIOImage(rgb, null, null), param);
+            writer.dispose();
+            ios.close();
+            images.add(new ImageInfo(baos.toByteArray(), rgb.getWidth(), rgb.getHeight()));
+        }
+        writePdf(images, outputPath);
+    }
+
+    private static void writePdf(List<ImageInfo> images, String outputPath) throws IOException {
+        ByteArrayOutputStream pdf = new ByteArrayOutputStream();
+        List<Integer> xref = new ArrayList<>();
+        pdf.write("%PDF-1.4\n".getBytes("ISO-8859-1"));
+
+        int objNum = 1;
+        xref.add(pdf.size());
+        pdf.write((objNum + " 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n").getBytes("ISO-8859-1"));
+        objNum++;
+
+        StringBuilder kids = new StringBuilder("[ ");
+        for (int i = 0; i < images.size(); i++) {
+            kids.append(3 + i * 3).append(" 0 R ");
+        }
+        kids.append("]");
+        xref.add(pdf.size());
+        pdf.write((objNum + " 0 obj\n<< /Type /Pages /Kids " + kids + " /Count " + images.size() + " >>\nendobj\n").getBytes("ISO-8859-1"));
+        objNum++;
+
+        for (int i = 0; i < images.size(); i++) {
+            ImageInfo img = images.get(i);
+            int pageObj = 3 + i * 3;
+            int imgObj = 4 + i * 3;
+            int contentObj = 5 + i * 3;
+
+            // page object will be written later after image and content to keep ordering
+            // image object
+            xref.add(pdf.size());
+            pdf.write((imgObj + " 0 obj\n<< /Type /XObject /Subtype /Image /Width " + img.width + " /Height " + img.height + " /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length " + img.data.length + " >>\nstream\n").getBytes("ISO-8859-1"));
+            pdf.write(img.data);
+            pdf.write("\nendstream\nendobj\n".getBytes("ISO-8859-1"));
+
+            // content object
+            String content = "q\n" + img.width + " 0 0 " + img.height + " 0 0 cm\n/Im1 Do\nQ";
+            byte[] contentBytes = content.getBytes("ISO-8859-1");
+            xref.add(pdf.size());
+            pdf.write((contentObj + " 0 obj\n<< /Length " + contentBytes.length + " >>\nstream\n").getBytes("ISO-8859-1"));
+            pdf.write(contentBytes);
+            pdf.write("\nendstream\nendobj\n".getBytes("ISO-8859-1"));
+
+            // page object
+            xref.add(pdf.size());
+            String pageStr = pageObj + " 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 " + img.width + " " + img.height + "] ";
+            pageStr += "/Resources << /XObject << /Im1 " + imgObj + " 0 R >> >> ";
+            pageStr += "/Contents " + contentObj + " 0 R >>\nendobj\n";
+            pdf.write(pageStr.getBytes("ISO-8859-1"));
+        }
+
+        int startXref = pdf.size();
+        pdf.write("xref\n".getBytes("ISO-8859-1"));
+        pdf.write(("0 " + (xref.size() + 1) + "\n").getBytes("ISO-8859-1"));
+        pdf.write("0000000000 65535 f \n".getBytes("ISO-8859-1"));
+        for (int offset : xref) {
+            String line = String.format("%010d 00000 n \n", offset);
+            pdf.write(line.getBytes("ISO-8859-1"));
+        }
+        pdf.write(("trailer\n<< /Size " + (xref.size() + 1) + " /Root 1 0 R >>\nstartxref\n" + startXref + "\n%%EOF").getBytes("ISO-8859-1"));
+
+        try (FileOutputStream fos = new FileOutputStream(outputPath)) {
+            pdf.writeTo(fos);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a lightweight `SimplePDFWriter` so the project no longer depends on Apache PDFBox
- update `PDFConverter` to use `SimplePDFWriter`

## Testing
- `javac PDFConverter.java SimplePDFWriter.java`

------
https://chatgpt.com/codex/tasks/task_b_683c0d7a4c108325b9278d859f7909dc